### PR TITLE
Add status icons: data-error, data-warning, data-information

### DIFF
--- a/icons-dark/status/16/data-error.svg
+++ b/icons-dark/status/16/data-error.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css" id="current-color-scheme">
+        .ColorScheme-NegativeText {
+            color:#da4453;
+        }
+    </style>
+    <rect class="ColorScheme-NegativeText" x="2" y="2" width="12" height="12" rx="2" fill="currentColor"/>
+    <path d="M 5.414,4 4,5.414 6.586,8 4,10.586 5.414,12 8,9.414 10.586,12 12,10.586 9.414,8 12,5.414 10.586,4 8,6.586 Z" fill="#fff"/>
+</svg>

--- a/icons-dark/status/16/data-information.svg
+++ b/icons-dark/status/16/data-information.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css" id="current-color-scheme">
+        .ColorScheme-Highlight {
+            color:#3daee9;
+        }
+    </style>
+    <rect class="ColorScheme-Highlight" x="2" y="2" width="12" height="12" rx="2" fill="currentColor"/>
+    <path d="m7 4v2h2v-2zm0 3v5h2v-5z" fill="#fff"/>
+</svg>

--- a/icons-dark/status/16/data-warning.svg
+++ b/icons-dark/status/16/data-warning.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css" id="current-color-scheme">
+        .ColorScheme-NeutralText {
+            color:#f67400;
+        }
+    </style>
+    <path class="ColorScheme-NeutralText" d="m8.0065001 2.0000269a0.75001881 0.74999832 0 0 0-0.6772669 0.414749l-5.2501316 10.499976a0.75001881 0.74999832 0 0 0 0.6712668 1.085248h10.500264a0.75001881 0.74999832 0 0 0 0.671266-1.085248l-5.2501312-10.499976a0.75001881 0.74999832 0 0 0-0.6652667-0.414749z" fill="currentColor"/>
+    <path d="m7 5v4h2v-4zm0 5v2h2v-2z" fill="#fff"/>
+</svg>

--- a/icons-dark/status/22/data-error.svg
+++ b/icons-dark/status/22/data-error.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css" id="current-color-scheme">
+        .ColorScheme-NegativeText {
+            color:#da4453;
+        }
+    </style>
+    <rect class="ColorScheme-NegativeText" x="3" y="3" width="16" height="16" rx="2" fill="currentColor"/>
+    <path d="M 6.414,5 5,6.414 9.586,11 5,15.586 6.414,17 11,12.414 15.586,17 17,15.586 12.414,11 17,6.414 15.586,5 11,9.586 Z" fill="#fff"/>
+</svg>

--- a/icons-dark/status/22/data-information.svg
+++ b/icons-dark/status/22/data-information.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css" id="current-color-scheme">
+        .ColorScheme-Highlight {
+            color:#3daee9;
+        }
+    </style>
+    <rect class="ColorScheme-Highlight" x="3" y="3" width="16" height="16" rx="2" fill="currentColor"/>
+    <path d="m10 6v2h2v-2zm0 4v6h2v-6z" fill="#fff"/>
+</svg>

--- a/icons-dark/status/22/data-warning.svg
+++ b/icons-dark/status/22/data-warning.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css" id="current-color-scheme">
+        .ColorScheme-NeutralText {
+            color:#f67400;
+        }
+    </style>
+    <path class="ColorScheme-NeutralText" d="m11.006318 3.0000261a0.72728737 0.72727154 0 0 0-0.65674 0.4021811l-7.2728738 14.545431a0.72728737 0.72727154 0 0 0 0.6509222 1.052362h14.545748a0.72728737 0.72727154 0 0 0 0.650922-1.052362l-7.272874-14.545431a0.72728737 0.72727154 0 0 0-0.645104-0.4021811z" fill="currentColor"/>
+    <path d="m10 7v6h2v-6zm0 8v2h2v-2z" fill="#fff"/>
+</svg>

--- a/icons/status/16/data-error.svg
+++ b/icons/status/16/data-error.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css" id="current-color-scheme">
+        .ColorScheme-NegativeText {
+            color:#da4453;
+        }
+    </style>
+    <rect class="ColorScheme-NegativeText" x="2" y="2" width="12" height="12" rx="2" fill="currentColor"/>
+    <path d="M 5.414,4 4,5.414 6.586,8 4,10.586 5.414,12 8,9.414 10.586,12 12,10.586 9.414,8 12,5.414 10.586,4 8,6.586 Z" fill="#fff"/>
+</svg>

--- a/icons/status/16/data-information.svg
+++ b/icons/status/16/data-information.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css" id="current-color-scheme">
+        .ColorScheme-Highlight {
+            color:#3daee9;
+        }
+    </style>
+    <rect class="ColorScheme-Highlight" x="2" y="2" width="12" height="12" rx="2" fill="currentColor"/>
+    <path d="m7 4v2h2v-2zm0 3v5h2v-5z" fill="#fff"/>
+</svg>

--- a/icons/status/16/data-warning.svg
+++ b/icons/status/16/data-warning.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css" id="current-color-scheme">
+        .ColorScheme-NeutralText {
+            color:#f67400;
+        }
+    </style>
+    <path class="ColorScheme-NeutralText" d="m8.0065001 2.0000269a0.75001881 0.74999832 0 0 0-0.6772669 0.414749l-5.2501316 10.499976a0.75001881 0.74999832 0 0 0 0.6712668 1.085248h10.500264a0.75001881 0.74999832 0 0 0 0.671266-1.085248l-5.2501312-10.499976a0.75001881 0.74999832 0 0 0-0.6652667-0.414749z" fill="currentColor"/>
+    <path d="m7 5v4h2v-4zm0 5v2h2v-2z" fill="#fff"/>
+</svg>

--- a/icons/status/22/data-error.svg
+++ b/icons/status/22/data-error.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css" id="current-color-scheme">
+        .ColorScheme-NegativeText {
+            color:#da4453;
+        }
+    </style>
+    <rect class="ColorScheme-NegativeText" x="3" y="3" width="16" height="16" rx="2" fill="currentColor"/>
+    <path d="M 6.414,5 5,6.414 9.586,11 5,15.586 6.414,17 11,12.414 15.586,17 17,15.586 12.414,11 17,6.414 15.586,5 11,9.586 Z" fill="#fff"/>
+</svg>

--- a/icons/status/22/data-information.svg
+++ b/icons/status/22/data-information.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css" id="current-color-scheme">
+        .ColorScheme-Highlight {
+            color:#3daee9;
+        }
+    </style>
+    <rect class="ColorScheme-Highlight" x="3" y="3" width="16" height="16" rx="2" fill="currentColor"/>
+    <path d="m10 6v2h2v-2zm0 4v6h2v-6z" fill="#fff"/>
+</svg>

--- a/icons/status/22/data-warning.svg
+++ b/icons/status/22/data-warning.svg
@@ -1,0 +1,9 @@
+<svg version="1.1" viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg">
+    <style type="text/css" id="current-color-scheme">
+        .ColorScheme-NeutralText {
+            color:#f67400;
+        }
+    </style>
+    <path class="ColorScheme-NeutralText" d="m11.006318 3.0000261a0.72728737 0.72727154 0 0 0-0.65674 0.4021811l-7.2728738 14.545431a0.72728737 0.72727154 0 0 0 0.6509222 1.052362h14.545748a0.72728737 0.72727154 0 0 0 0.650922-1.052362l-7.272874-14.545431a0.72728737 0.72727154 0 0 0-0.645104-0.4021811z" fill="currentColor"/>
+    <path d="m10 7v5h2v-5zm0 7v2h2v-2z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
Summary:
These are generic icons to use to mark the status of data or other content.
The current available icons are bound to other context, like dialog or
cloud.

Use case of such icons would be e.g. with KDevelop to put such lines on the
marker border to mark lines with errors, warnings or hints as found by
parsers & checkers by a symbol, as well as in the problem report tool view
or as symbols in inline notes.
Those places use small icons, and best signal the type of marker by both
shape & color.

Reviewers: #vdg, ndavis

Reviewed By: #vdg, ndavis

Subscribers: #kdevelop, ngraham, davidre, kde-frameworks-devel

Tags: #frameworks

Differential Revision: https://phabricator.kde.org/D27272